### PR TITLE
Updated Pokestop

### DIFF
--- a/content/entities2.xml
+++ b/content/entities2.xml
@@ -35,7 +35,7 @@
 		id="5" name="Ultra Ball" numGridCollisionPoints="24" shadowSize="16" stageHP="0" variant="300" subtype="153">
 	</entity>
 	<entity anm2path="slot_pokestop.anm2" baseHP="0" boss="0" champion="0" collisionDamage="0" collisionMass="0" collisionRadius="60" friction="0"
-		id="6" name="Poke Stop" numGridCollisionPoints="24" shadowSize="0" stageHP="0" variant="1333">
+		id="5" name="Poke Stop" numGridCollisionPoints="24" shadowSize="0" stageHP="0" variant="1333">
     </entity>
 	<entity anm2path="effect_eevee_ghost.anm2" baseHP="0" boss="0" champion="0" collisionDamage="0" collisionMass="0" collisionRadius="0" friction="0"
 		id="1000" name="Eevee Ghost" numGridCollisionPoints="0" shadowSize="0" stageHP="0" variant="1333">


### PR DESCRIPTION
Pokestop on exit room exploit removed, fixed mass isues and collision class aswell as made it morphable on d20. Randomized the pickups dropped seed to not be clones on D20 use.
Note(Delete after merge): Changed spawn method to vanilla, you migh wat to change mod spawn method to not use seed if not given. Also i can't push to the main 